### PR TITLE
Used APP_ROOT for installing assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Used `APP_ROOT` for installing assets.
+
 ## [1.2.0] 2024-02-12
 
 ### Fixed

--- a/Services/OmniSearch.php
+++ b/Services/OmniSearch.php
@@ -3,22 +3,38 @@
 namespace Leantime\Plugins\OmniSearch\Services;
 
 class OmniSearch {
+  private static $assets = [
+    // source => target
+    __DIR__. '/../assets/js/omniSearch.js' => APP_ROOT . '/public/dist/js/omniSearch.js',
+    __DIR__. '/../assets/css/omniSearch.css' => APP_ROOT . '/public/dist/css/omniSearch.css',
+  ];
 
-  public function install() {
-    symlink(dirname(__DIR__). "/assets/js/omniSearch.js", $_SERVER['DOCUMENT_ROOT'] . "/dist/js/omniSearch.js");
-    symlink(dirname(__DIR__). "/assets/css/omniSearch.css", $_SERVER['DOCUMENT_ROOT'] . "/dist/css/omniSearch.css");
+  /**
+   * Install plugin.
+   *
+   * @return void
+   */
+  public function install(): void
+  {
+    foreach (static::$assets as $source => $target) {
+      if (file_exists($target)) {
+        unlink($target);
+      }
+      symlink($source, $target);
+    }
   }
 
-  public function uninstall() {
-    $omniSelectFiles = [
-        $_SERVER['DOCUMENT_ROOT'] . "/dist/js/omniSearch.js",
-        $_SERVER['DOCUMENT_ROOT'] . "/dist/css/omniSearch.css"
-      ];
-
-      foreach ($omniSelectFiles as $file) {
-        if (file_exists($file)) {
-          unlink($file);
-        }
+  /**
+   * Uninstall plugin.
+   *
+   * @return void
+   */
+  public function uninstall(): void
+  {
+    foreach (static::$assets as $target) {
+      if (file_exists($target)) {
+        unlink($target);
       }
+    }
   }
 }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/890

#### Description

Uses `APP_ROOT` for installing assets. `$_SERVER['DOCUMENT_ROOT']` is not sound to use when installing from command line. 

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

