### PR TITLE
Feature: Add language fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-36](https://github.com/ITK-Leantime/leantime-omnisearch/pull/36)
+  * Add fallback to unsupported languages
+
 * [PR-35](https://github.com/ITK-Leantime/leantime-omnisearch/pull/35)
   * Upgrade omnisearch plugin leantime 3 4 3
   * Added the itkdev markdownlinter (and markdownlinter ignore file)

--- a/Middleware/GetLanguageAssets.php
+++ b/Middleware/GetLanguageAssets.php
@@ -40,7 +40,6 @@ class GetLanguageAssets
             $languageArray += parse_ini_file(__DIR__ . '/../Language/en-US.ini', true);
         }
 
-        // @phpstan-ignore-next-line
         if (($language = $this->config->language ?? session('usersettings.language')) !== 'en-US') {
             if (!Cache::store('installation')->has('timeTable.language.' . $language)) {
                 $languageIniPath = __DIR__ . '/../Language/' . $language . '.ini';

--- a/Middleware/GetLanguageAssets.php
+++ b/Middleware/GetLanguageAssets.php
@@ -41,15 +41,19 @@ class GetLanguageAssets
         }
 
         // @phpstan-ignore-next-line
-        if (($language = session('usersettings.language') ?? $this->config->language) !== 'en-US') {
-            if (! Cache::store('installation')->has('omniSearch.language.' . $language)) {
+        if (($language = $this->config->language ?? session('usersettings.language')) !== 'en-US') {
+            if (!Cache::store('installation')->has('timeTable.language.' . $language)) {
+                $languageIniPath = __DIR__ . '/../Language/' . $language . '.ini';
+                if (!file_exists($languageIniPath)) {
+                    $languageIniPath = __DIR__ . '/../Language/en-US.ini';
+                }
                 Cache::store('installation')->put(
-                    'omniSearch.language.' . $language,
-                    parse_ini_file(__DIR__ . '/../Language/' . $language . '.ini', true)
+                    'timeTable.language.' . $language,
+                    parse_ini_file($languageIniPath, true)
                 );
             }
 
-            $languageArray = array_merge($languageArray, Cache::store('installation')->get('omniSearch.language.' . $language));
+            $languageArray = array_merge($languageArray, Cache::store('installation')->get('timeTable.language.' . $language));
         }
 
         Cache::put('omniSearch.languageArray', $languageArray);

--- a/assets/omniSearch.js
+++ b/assets/omniSearch.js
@@ -447,8 +447,8 @@ $(document).ready(function ($) {
           cache: true,
         },
         language: {
-          searching: function() {
-            return "Søger... Hvis det tager lang tid, kan du overveje at slå søgning i tidsregistreringer fra.";
+          searching: function () {
+            return 'Søger... Hvis det tager lang tid, kan du overveje at slå søgning i tidsregistreringer fra.';
           },
         },
         placeholder: getOmnisearchPreviewText(),


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/show#/tickets/showTicket/4029

#### Description

Trying to install or use a plugin with a language selected which is not either da-DK og en-US will cause an error. We should fallback to en-US if no .ini file matches currently selected language.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
